### PR TITLE
Fix crash with StatsDisplay.

### DIFF
--- a/gamedata/scripts/outfit_speed.script
+++ b/gamedata/scripts/outfit_speed.script
@@ -1,0 +1,1 @@
+-- Intentionally left blank --


### PR DESCRIPTION
StatsDisplay addon tries to load this script for compatibility patching, but having this file blank (zero-byte) causes Anomaly to crash with an "invalid parameter" error.

This file needs to be blank, but it also needs to be a valid lua script. Adding a single comment line should fix the issue.

Fixes #1.